### PR TITLE
Fix missing imports in dashboard and habits fragments

### DIFF
--- a/app/src/main/java/com/yourcompany/wellnessjourney/ui/DashboardFragment.kt
+++ b/app/src/main/java/com/yourcompany/wellnessjourney/ui/DashboardFragment.kt
@@ -6,14 +6,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.CheckBox
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
-import androidx.cardview.widget.CardView
+import android.widget.Toast
 
 import androidx.fragment.app.Fragment
 import com.yourcompany.wellnessjourney.R
+import com.yourcompany.wellnessjourney.MainActivity
 import com.yourcompany.wellnessjourney.data.Habit
 import com.yourcompany.wellnessjourney.data.HabitManager
 import java.text.SimpleDateFormat

--- a/app/src/main/java/com/yourcompany/wellnessjourney/ui/HabitsFragment.kt
+++ b/app/src/main/java/com/yourcompany/wellnessjourney/ui/HabitsFragment.kt
@@ -21,7 +21,6 @@ import com.yourcompany.wellnessjourney.R
 import com.yourcompany.wellnessjourney.adapters.HabitAdapter
 import com.yourcompany.wellnessjourney.data.Habit
 import com.yourcompany.wellnessjourney.data.HabitManager // We'll create this soon!
-import java.util.UUID
 
 class HabitsFragment : Fragment(R.layout.fragment_habits)
 {


### PR DESCRIPTION
## Summary
- add the missing imports in `DashboardFragment` so the dashboard can reference `MainActivity` and Android UI widgets without compilation errors
- remove the unused `UUID` import from `HabitsFragment` to keep the fragment free of unnecessary references

## Testing
- not run (Android SDK not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd3732a1a88321aeac5a67cf345ff8