### PR TITLE
Correct malformed attributes in dashboard layout

### DIFF
--- a/app/src/main/java/com/yourcompany/wellnessjourney/ui/DashboardFragment.kt
+++ b/app/src/main/java/com/yourcompany/wellnessjourney/ui/DashboardFragment.kt
@@ -6,14 +6,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.CheckBox
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
-import androidx.cardview.widget.CardView
+import android.widget.Toast
 
 import androidx.fragment.app.Fragment
 import com.yourcompany.wellnessjourney.R
+import com.yourcompany.wellnessjourney.MainActivity
 import com.yourcompany.wellnessjourney.data.Habit
 import com.yourcompany.wellnessjourney.data.HabitManager
 import java.text.SimpleDateFormat

--- a/app/src/main/java/com/yourcompany/wellnessjourney/ui/HabitsFragment.kt
+++ b/app/src/main/java/com/yourcompany/wellnessjourney/ui/HabitsFragment.kt
@@ -21,7 +21,6 @@ import com.yourcompany.wellnessjourney.R
 import com.yourcompany.wellnessjourney.adapters.HabitAdapter
 import com.yourcompany.wellnessjourney.data.Habit
 import com.yourcompany.wellnessjourney.data.HabitManager // We'll create this soon!
-import java.util.UUID
 
 class HabitsFragment : Fragment(R.layout.fragment_habits)
 {

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -13,10 +13,10 @@
         android:id="@+id/top_background_view"
         android:layout_width="0dp"
         android:layout_height="200dp"
-    android:background="@drawable/dashboard_gradient_bg"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
+        android:background="@drawable/dashboard_gradient_bg"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <!-- Dashboard Header -->
     <TextView
@@ -179,14 +179,14 @@
         android:id="@+id/text_quick_stats_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-    android:layout_marginStart="16dp"
-    android:layout_marginTop="16dp"
-    android:text="@string/quick_stats_title"
-    android:textColor="@color/text_dark"
-    android:textSize="18sp"
-    android:textStyle="bold"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/card_progress_section" />
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:text="@string/quick_stats_title"
+        android:textColor="@color/text_dark"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/card_progress_section" />
 
     <GridLayout
         android:id="@+id/grid_quick_stats"
@@ -285,127 +285,125 @@
 
         <!-- Quick Stat 3: Habits Done -->
         <androidx.cardview.widget.CardView
-            android:"@+id/card_habits_done"
+            android:id="@+id/card_habits_done"
             android:layout_width="0dp"
-            android://layout_height="wrap_content"
-        android:layout_rowWeight="1"
-        android:layout_columnWeight="1"
-        android:layout_margin="8dp"
-        app:cardCornerRadius="12dp"
-        app:cardElevation="4dp">
-
-        <LinearLayout
-            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:gravity="center"
-            android:padding="12dp"
-            android:background="@color/quick_stat_bg_habits_done">
-            <ImageView
-                android:layout_width="32dp"
-                android:layout_height="32dp"
-                android:src="@drawable/ic_habits"
-                app:tint="@color/text_dark"
-                android:contentDescription="@string/content_desc_habits_done" />
-            <TextView
-                android:id="@+id/text_habits_done_count"
-                android:layout_width="wrap_content"
+            android:layout_rowWeight="1"
+            android:layout_columnWeight="1"
+            android:layout_margin="8dp"
+            app:cardCornerRadius="12dp"
+            app:cardElevation="4dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                tools:text="0/4"
-                android:textSize="14sp"
-                android:textColor="@color/text_dark"
-                android:layout_marginTop="8dp"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/habits_done_label"
-                android:textSize="12sp"
-                android:textColor="@color/text_light"/>
-        </LinearLayout>
-    </androidx.cardview.widget.CardView>
-
-
-    <androidx.cardview.widget.CardView
-        android:id="@+id/card_streak"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_rowWeight="1"
-        android:layout_columnWeight="1"
-        android:layout_margin="8dp"
-        app:cardCornerRadius="12dp"
-        app:cardElevation="4dp">
-
-        <LinearLayout
-            android:layout_width="match_parent"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:padding="12dp"
+                android:background="@color/quick_stat_bg_habits_done">
+                <ImageView
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:src="@drawable/ic_habits"
+                    app:tint="@color/text_dark"
+                    android:contentDescription="@string/content_desc_habits_done" />
+                <TextView
+                    android:id="@+id/text_habits_done_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:textSize="14sp"
+                    android:textColor="@color/text_dark"
+                    tools:text="0/4" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/habits_done_label"
+                    android:textSize="12sp"
+                    android:textColor="@color/text_light" />
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+        <androidx.cardview.widget.CardView
+            android:id="@+id/card_streak"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:gravity="center"
-            android:padding="12dp"
-            android:background="@color/quick_stat_bg_streak">
-            <ImageView
-                android:layout_width="32dp"
-                android:layout_height="32dp"
-                android:src="@drawable/ic_streak"
-                app:tint="@color/text_dark"
-                android:contentDescription="@string/content_desc_streak_count" />
-            <TextView
-                android:id="@+id/text_streak_count"
-                android:layout_width="wrap_content"
+            android:layout_rowWeight="1"
+            android:layout_columnWeight="1"
+            android:layout_margin="8dp"
+            app:cardCornerRadius="12dp"
+            app:cardElevation="4dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                tools:text="7 Days"
-                android:textSize="14sp"
-                android:textColor="@color/text_dark"
-                android:layout_marginTop="8dp"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/streak_label"
-                android:textSize="12sp"
-                android:textColor="@color/text_light"/>
-        </LinearLayout>
-    </androidx.cardview.widget.CardView>
+                android:orientation="vertical"
+                android:gravity="center"
+                android:padding="12dp"
+                android:background="@color/quick_stat_bg_streak">
+                <ImageView
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:src="@drawable/ic_streak"
+                    app:tint="@color/text_dark"
+                    android:contentDescription="@string/content_desc_streak_count" />
+                <TextView
+                    android:id="@+id/text_streak_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:textSize="14sp"
+                    android:textColor="@color/text_dark"
+                    tools:text="7 Days" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/streak_label"
+                    android:textSize="12sp"
+                    android:textColor="@color/text_light" />
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
 
 </GridLayout>
 
 
-<TextView
-android:id="@+id/text_todays_habits_title"
-android:layout_width="wrap_content"
-android:layout_height="wrap_content"
-android:layout_marginStart="16dp"
-android:layout_marginTop="16dp"
-android:text="@string/todays_habits_title"
-android:textColor="@color/text_dark"
-android:textSize="18sp"
-android:textStyle="bold"
-app:layout_constraintStart_toStartOf="parent"
-app:layout_constraintTop_toBottomOf="@+id/grid_quick_stats" />
+    <TextView
+        android:id="@+id/text_todays_habits_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:text="@string/todays_habits_title"
+        android:textColor="@color/text_dark"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/grid_quick_stats" />
 
     <!-- A placeholder for the habits list, which will be populated dynamically -->
-<LinearLayout>
-android:id="@+id/layout_todays_habits_list"
-android:layout_width="0dp"
-android:layout_height="0dp"
-android:orientation="vertical"
-android:paddingStart="8dp"
-android:paddingEnd="8dp"
-android:layout_marginTop="8dp"
-app:layout_constraintEnd_toEndOf="parent"
-app:layout_constraintStart_toStartOf="parent"
-app:layout_constraintTop_toBottomOf="@+id/text_todays_habits_title"
-app:layout_constraintBottom_toBottomOf="parent">
+    <LinearLayout
+        android:id="@+id/layout_todays_habits_list"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_todays_habits_title">
 
-<TextView
-    android:id="@+id/text_no_habits_placeholder"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:text="@string/no_habits_set_placeholder"
-    android:gravity="center"
-    android:textColor="@color/text_light"
-    android:layout_margin="16dp"
-    android:visibility="visible"/>
+        <TextView
+            android:id="@+id/text_no_habits_placeholder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:gravity="center"
+            android:text="@string/no_habits_set_placeholder"
+            android:textColor="@color/text_light"
+            android:visibility="visible" />
 
-<!-- Habits will be dynamically added here -->
-</LinearLayout>
+        <!-- Habits will be dynamically added here -->
+    </LinearLayout>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- correct malformed android attribute declarations in `fragment_dashboard.xml` so the quick stat cards parse correctly
- restore the proper indentation and constraint structure for the quick stats grid and today's habits section to keep the layout valid XML

## Testing
- ./gradlew test *(fails: Android SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3732a1a88321aeac5a67cf345ff8