### PR TITLE
Add missing dashboard text resources and streak icon

### DIFF
--- a/app/src/main/java/com/yourcompany/wellnessjourney/ui/DashboardFragment.kt
+++ b/app/src/main/java/com/yourcompany/wellnessjourney/ui/DashboardFragment.kt
@@ -6,14 +6,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.CheckBox
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
-import androidx.cardview.widget.CardView
+import android.widget.Toast
 
 import androidx.fragment.app.Fragment
 import com.yourcompany.wellnessjourney.R
+import com.yourcompany.wellnessjourney.MainActivity
 import com.yourcompany.wellnessjourney.data.Habit
 import com.yourcompany.wellnessjourney.data.HabitManager
 import java.text.SimpleDateFormat

--- a/app/src/main/java/com/yourcompany/wellnessjourney/ui/HabitsFragment.kt
+++ b/app/src/main/java/com/yourcompany/wellnessjourney/ui/HabitsFragment.kt
@@ -21,7 +21,6 @@ import com.yourcompany.wellnessjourney.R
 import com.yourcompany.wellnessjourney.adapters.HabitAdapter
 import com.yourcompany.wellnessjourney.data.Habit
 import com.yourcompany.wellnessjourney.data.HabitManager // We'll create this soon!
-import java.util.UUID
 
 class HabitsFragment : Fragment(R.layout.fragment_habits)
 {

--- a/app/src/main/res/drawable/ic_streak.xml
+++ b/app/src/main/res/drawable/ic_streak.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2l2.09,6.26h6.58l-5.33,3.88L17.42,18L12,13.97 6.58,18l1.08,-5.86L2.33,8.26h6.58L12,2z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -13,10 +13,10 @@
         android:id="@+id/top_background_view"
         android:layout_width="0dp"
         android:layout_height="200dp"
-    android:background="@drawable/dashboard_gradient_bg"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
+        android:background="@drawable/dashboard_gradient_bg"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <!-- Dashboard Header -->
     <TextView
@@ -179,14 +179,14 @@
         android:id="@+id/text_quick_stats_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-    android:layout_marginStart="16dp"
-    android:layout_marginTop="16dp"
-    android:text="@string/quick_stats_title"
-    android:textColor="@color/text_dark"
-    android:textSize="18sp"
-    android:textStyle="bold"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/card_progress_section" />
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:text="@string/quick_stats_title"
+        android:textColor="@color/text_dark"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/card_progress_section" />
 
     <GridLayout
         android:id="@+id/grid_quick_stats"
@@ -285,127 +285,125 @@
 
         <!-- Quick Stat 3: Habits Done -->
         <androidx.cardview.widget.CardView
-            android:"@+id/card_habits_done"
+            android:id="@+id/card_habits_done"
             android:layout_width="0dp"
-            android://layout_height="wrap_content"
-        android:layout_rowWeight="1"
-        android:layout_columnWeight="1"
-        android:layout_margin="8dp"
-        app:cardCornerRadius="12dp"
-        app:cardElevation="4dp">
-
-        <LinearLayout
-            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:gravity="center"
-            android:padding="12dp"
-            android:background="@color/quick_stat_bg_habits_done">
-            <ImageView
-                android:layout_width="32dp"
-                android:layout_height="32dp"
-                android:src="@drawable/ic_habits"
-                app:tint="@color/text_dark"
-                android:contentDescription="@string/content_desc_habits_done" />
-            <TextView
-                android:id="@+id/text_habits_done_count"
-                android:layout_width="wrap_content"
+            android:layout_rowWeight="1"
+            android:layout_columnWeight="1"
+            android:layout_margin="8dp"
+            app:cardCornerRadius="12dp"
+            app:cardElevation="4dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                tools:text="0/4"
-                android:textSize="14sp"
-                android:textColor="@color/text_dark"
-                android:layout_marginTop="8dp"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/habits_done_label"
-                android:textSize="12sp"
-                android:textColor="@color/text_light"/>
-        </LinearLayout>
-    </androidx.cardview.widget.CardView>
-
-
-    <androidx.cardview.widget.CardView
-        android:id="@+id/card_streak"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_rowWeight="1"
-        android:layout_columnWeight="1"
-        android:layout_margin="8dp"
-        app:cardCornerRadius="12dp"
-        app:cardElevation="4dp">
-
-        <LinearLayout
-            android:layout_width="match_parent"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:padding="12dp"
+                android:background="@color/quick_stat_bg_habits_done">
+                <ImageView
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:src="@drawable/ic_habits"
+                    app:tint="@color/text_dark"
+                    android:contentDescription="@string/content_desc_habits_done" />
+                <TextView
+                    android:id="@+id/text_habits_done_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:textSize="14sp"
+                    android:textColor="@color/text_dark"
+                    tools:text="0/4" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/habits_done_label"
+                    android:textSize="12sp"
+                    android:textColor="@color/text_light" />
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+        <androidx.cardview.widget.CardView
+            android:id="@+id/card_streak"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:gravity="center"
-            android:padding="12dp"
-            android:background="@color/quick_stat_bg_streak">
-            <ImageView
-                android:layout_width="32dp"
-                android:layout_height="32dp"
-                android:src="@drawable/ic_streak"
-                app:tint="@color/text_dark"
-                android:contentDescription="@string/content_desc_streak_count" />
-            <TextView
-                android:id="@+id/text_streak_count"
-                android:layout_width="wrap_content"
+            android:layout_rowWeight="1"
+            android:layout_columnWeight="1"
+            android:layout_margin="8dp"
+            app:cardCornerRadius="12dp"
+            app:cardElevation="4dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                tools:text="7 Days"
-                android:textSize="14sp"
-                android:textColor="@color/text_dark"
-                android:layout_marginTop="8dp"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/streak_label"
-                android:textSize="12sp"
-                android:textColor="@color/text_light"/>
-        </LinearLayout>
-    </androidx.cardview.widget.CardView>
+                android:orientation="vertical"
+                android:gravity="center"
+                android:padding="12dp"
+                android:background="@color/quick_stat_bg_streak">
+                <ImageView
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:src="@drawable/ic_streak"
+                    app:tint="@color/text_dark"
+                    android:contentDescription="@string/content_desc_streak_count" />
+                <TextView
+                    android:id="@+id/text_streak_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:textSize="14sp"
+                    android:textColor="@color/text_dark"
+                    tools:text="7 Days" />
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/streak_label"
+                    android:textSize="12sp"
+                    android:textColor="@color/text_light" />
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
 
 </GridLayout>
 
 
-<TextView
-android:id="@+id/text_todays_habits_title"
-android:layout_width="wrap_content"
-android:layout_height="wrap_content"
-android:layout_marginStart="16dp"
-android:layout_marginTop="16dp"
-android:text="@string/todays_habits_title"
-android:textColor="@color/text_dark"
-android:textSize="18sp"
-android:textStyle="bold"
-app:layout_constraintStart_toStartOf="parent"
-app:layout_constraintTop_toBottomOf="@+id/grid_quick_stats" />
+    <TextView
+        android:id="@+id/text_todays_habits_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:text="@string/todays_habits_title"
+        android:textColor="@color/text_dark"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/grid_quick_stats" />
 
     <!-- A placeholder for the habits list, which will be populated dynamically -->
-<LinearLayout>
-android:id="@+id/layout_todays_habits_list"
-android:layout_width="0dp"
-android:layout_height="0dp"
-android:orientation="vertical"
-android:paddingStart="8dp"
-android:paddingEnd="8dp"
-android:layout_marginTop="8dp"
-app:layout_constraintEnd_toEndOf="parent"
-app:layout_constraintStart_toStartOf="parent"
-app:layout_constraintTop_toBottomOf="@+id/text_todays_habits_title"
-app:layout_constraintBottom_toBottomOf="parent">
+    <LinearLayout
+        android:id="@+id/layout_todays_habits_list"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/text_todays_habits_title">
 
-<TextView
-    android:id="@+id/text_no_habits_placeholder"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:text="@string/no_habits_set_placeholder"
-    android:gravity="center"
-    android:textColor="@color/text_light"
-    android:layout_margin="16dp"
-    android:visibility="visible"/>
+        <TextView
+            android:id="@+id/text_no_habits_placeholder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:gravity="center"
+            android:text="@string/no_habits_set_placeholder"
+            android:textColor="@color/text_light"
+            android:visibility="visible" />
 
-<!-- Habits will be dynamically added here -->
-</LinearLayout>
+        <!-- Habits will be dynamically added here -->
+    </LinearLayout>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,26 @@
 <resources>
     <string name="app_name">WellnessJourney</string>
 
+    <string name="wellness_dashboard_title">Your Wellness Dashboard</string>
+    <string name="todays_progress_title">Today's Progress</string>
+    <string name="label_habits">Habits</string>
+    <string name="label_hydration">Hydration</string>
+    <string name="reset_app_data_debug">Reset App Data (Debug)</string>
+    <string name="quick_stats_title">Quick Stats</string>
+    <string name="content_desc_today_mood">Today's recorded mood icon</string>
+    <string name="todays_mood_label">Today's Mood</string>
+    <string name="content_desc_water_intake">Water intake progress icon</string>
+    <string name="water_intake_label">Water Intake</string>
+    <string name="content_desc_habits_done">Habits completed icon</string>
+    <string name="habits_done_label">Habits Done</string>
+    <string name="content_desc_streak_count">Streak count badge</string>
+    <string name="streak_label">Current Streak</string>
+    <string name="todays_habits_title">Today's Habits</string>
+    <string name="no_habits_set_placeholder">No habits added yet. Create one to get started!</string>
+    <string name="hydration_tracker_screen_title">Hydration Tracker</string>
+    <string name="mood_journal_screen_title">Mood Journal</string>
+    <string name="content_desc_habit_icon">Icon representing the habit</string>
+
     <string-array name="habit_icons_array">
         <item>No Icon (Default)</item>
         <item>Exercise Icon</item>


### PR DESCRIPTION
## Summary
- add the dashboard, quick stats, and hydration screen strings referenced by the layouts
- create a streak icon drawable so the quick stats card can render correctly

## Testing
- ./gradlew test *(fails: Android SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3732a1a88321aeac5a67cf345ff8