### PR TITLE
Enable AndroidX support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- add a gradle.properties file enabling AndroidX and Jetifier so the project can resolve AndroidX dependencies

## Testing
- unable to run `./gradlew assembleDebug` (fails to download Gradle distribution due to proxy restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68dd438066488321abd93a64f892ca65