### PR TITLE
Fix missing mood chip background color resource

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -14,6 +14,7 @@
     <color name="hydration_track">#D6F3FF</color>
     <color name="chip_background">#EEF2FF</color>
     <color name="chip_selected">#DDE3FF</color>
+    <color name="mood_chip_background">#FFFFFF</color>
     <color name="chip_text">#1F2933</color>
     <color name="icon_default_bg">#FFFFFF</color>
     <color name="mood_selected">#E0F2F1</color>


### PR DESCRIPTION
## Summary
- add the missing `mood_chip_background` color definition used by the mood chip style

## Testing
- not run (gradle wrapper download blocked in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd7f34a138832195c920faa72e6dc3