### PR TITLE
Fix malformed ic_launcher background resource file

### DIFF
--- a/app/src/main/res/values/ic_launcher_background.xml
+++ b/app/src/main/res/values/ic_launcher_background.xml
@@ -1,2 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?> <resources>
-    <color name="ic_launcher_background">#004D40</color> </resources>
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#004D40</color>
+</resources>


### PR DESCRIPTION
## Summary
- format the ic_launcher_background color resource as a valid XML document

## Testing
- not run (Android SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de3647316c8321803703fbc336c8bc