### PR TITLE
Add DataManager helper for widget completion percentage

### DIFF
--- a/app/src/main/java/com/wellness/app/utils/DataManager.kt
+++ b/app/src/main/java/com/wellness/app/utils/DataManager.kt
@@ -140,6 +140,11 @@ class DataManager(context: Context) {
         )
     }
 
+    fun getTodayCompletionPercentage(): Float {
+        val summary = getHabitSummary()
+        return summary.completionPercentage.coerceIn(0f, 100f)
+    }
+
     fun getHabitStreak(): Int {
         val habits = getHabits()
         if (habits.isEmpty()) return 0


### PR DESCRIPTION
## Summary
- add a `getTodayCompletionPercentage` helper to `DataManager`
- clamp the returned value between 0 and 100 for safe widget display

## Testing
- not run (Android SDK not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de3dc45400832180356935c4ecb030