### PR TITLE
Fix Material theme color attributes for Material3

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.WellnessTracker" parent="Theme.Material3.DayNight">
+    <style name="Theme.WellnessTracker" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorOnPrimary">@color/white</item>
+        <item name="colorPrimaryContainer">@color/purple_200</item>
         <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
+        <item name="colorSecondaryContainer">@color/teal_700</item>
         <item name="android:statusBarColor">@color/purple_700</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- update the app theme to inherit from the Material 3 no-action-bar base theme
- replace deprecated color variant attributes with Material 3 container color entries to avoid resource merge failures

## Testing
- `./gradlew :app:mergeDebugResources --stacktrace` *(fails: dependency downloads are blocked with HTTP 403 responses in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dec66465188321b88f5ba5449f785e