### PR TITLE
Fix unresolved references in habit screens

### DIFF
--- a/app/src/main/java/com/wellnesstracker/adapters/HabitAdapter.kt
+++ b/app/src/main/java/com/wellnesstracker/adapters/HabitAdapter.kt
@@ -34,7 +34,7 @@ class HabitAdapter(
             updateProgressState(dataManager.isHabitCompleted(habit.id, today))
 
             binding.buttonPlus.setOnClickListener {
-                val position = bindingAdapterPosition
+                val position = absoluteAdapterPosition
                 if (position != RecyclerView.NO_POSITION) {
                     val completed = dataManager.isHabitCompleted(habit.id, today)
                     if (!completed) {
@@ -47,7 +47,7 @@ class HabitAdapter(
             }
 
             binding.buttonMinus.setOnClickListener {
-                val position = bindingAdapterPosition
+                val position = absoluteAdapterPosition
                 if (position != RecyclerView.NO_POSITION) {
                     val completed = dataManager.isHabitCompleted(habit.id, today)
                     if (completed) {

--- a/app/src/main/java/com/wellnesstracker/fragments/HabitsFragment.kt
+++ b/app/src/main/java/com/wellnesstracker/fragments/HabitsFragment.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.wellnesstracker.R
 import com.wellnesstracker.adapters.HabitAdapter
 import com.wellnesstracker.databinding.FragmentHabitsBinding
 import com.wellnesstracker.dialogs.AddHabitDialog


### PR DESCRIPTION
## Summary
- replace the use of `bindingAdapterPosition` with `absoluteAdapterPosition` in `HabitAdapter` to avoid unresolved reference errors
- import the app `R` class in `HabitsFragment` so resource lookups compile

## Testing
- `./gradlew assembleDebug` *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e18cd66cb8832197c2e98cf6fe1a47