### PR TITLE
Fix adapter position lookups in HabitAdapter

### DIFF
--- a/app/src/main/java/com/wellnesstracker/adapters/HabitAdapter.kt
+++ b/app/src/main/java/com/wellnesstracker/adapters/HabitAdapter.kt
@@ -34,7 +34,8 @@ class HabitAdapter(
             updateProgressState(dataManager.isHabitCompleted(habit.id, today))
 
             binding.buttonPlus.setOnClickListener {
-                val position = bindingAdapterPosition
+                @Suppress("DEPRECATION")
+                val position = adapterPosition
                 if (position != RecyclerView.NO_POSITION) {
                     val completed = dataManager.isHabitCompleted(habit.id, today)
                     if (!completed) {
@@ -47,7 +48,8 @@ class HabitAdapter(
             }
 
             binding.buttonMinus.setOnClickListener {
-                val position = bindingAdapterPosition
+                @Suppress("DEPRECATION")
+                val position = adapterPosition
                 if (position != RecyclerView.NO_POSITION) {
                     val completed = dataManager.isHabitCompleted(habit.id, today)
                     if (completed) {

--- a/app/src/main/java/com/wellnesstracker/fragments/HabitsFragment.kt
+++ b/app/src/main/java/com/wellnesstracker/fragments/HabitsFragment.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.wellnesstracker.R
 import com.wellnesstracker.adapters.HabitAdapter
 import com.wellnesstracker.databinding.FragmentHabitsBinding
 import com.wellnesstracker.dialogs.AddHabitDialog


### PR DESCRIPTION
## Summary
- switch HabitAdapter to use adapterPosition for compatibility with older RecyclerView releases
- suppress the deprecation warnings locally so the position lookup stays safe for NO_POSITION checks

## Testing
- ./gradlew assembleDebug *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e18cd66cb8832197c2e98cf6fe1a47