### PR TITLE
Improve readability of header text

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -26,7 +26,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/welcome_back"
-                    android:textColor="@color/white"
+                    android:textColor="@color/color_text_secondary"
                     android:textSize="20sp" />
 
                 <TextView
@@ -34,7 +34,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:text="@string/log_in_title"
-                    android:textColor="@color/white"
+                    android:textColor="@color/color_text_primary"
                     android:textSize="28sp"
                     android:textStyle="bold" />
             </LinearLayout>

--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -26,7 +26,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/welcome_to_app"
-                    android:textColor="@color/white"
+                    android:textColor="@color/color_text_secondary"
                     android:textSize="20sp" />
 
                 <TextView
@@ -34,7 +34,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
                     android:text="@string/create_account"
-                    android:textColor="@color/white"
+                    android:textColor="@color/color_text_primary"
                     android:textSize="28sp"
                     android:textStyle="bold" />
             </LinearLayout>

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -33,7 +33,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/dashboard_title"
-                    android:textColor="@color/white"
+                    android:textColor="@color/color_text_primary"
                     android:textSize="26sp"
                     android:textStyle="bold" />
 
@@ -42,7 +42,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="6dp"
-                    android:textColor="@color/white"
+                    android:textColor="@color/color_text_secondary"
                     android:textSize="14sp" />
 
                 <TextView
@@ -50,7 +50,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="24dp"
                     android:text="@string/todays_progress"
-                    android:textColor="@color/white"
+                    android:textColor="@color/color_text_primary"
                     android:textSize="16sp"
                     android:textStyle="bold" />
 
@@ -173,9 +173,9 @@
                     android:layout_marginTop="20dp"
                     android:text="@string/reset_onboarding"
                     android:textAllCaps="false"
-                    android:textColor="@color/white"
+                    android:textColor="@color/color_secondary"
                     app:backgroundTint="@android:color/transparent"
-                    app:strokeColor="@color/white"
+                    app:strokeColor="@color/color_secondary"
                     app:strokeWidth="1dp" />
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/fragment_habits.xml
+++ b/app/src/main/res/layout/fragment_habits.xml
@@ -35,7 +35,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/habits_title"
-                        android:textColor="@color/white"
+                        android:textColor="@color/color_text_primary"
                         android:textSize="26sp"
                         android:textStyle="bold" />
 
@@ -44,7 +44,7 @@
                         android:layout_height="wrap_content"
                         android:layout_marginTop="6dp"
                         android:text="@string/habits_subtitle"
-                        android:textColor="@color/white"
+                        android:textColor="@color/color_text_secondary"
                         android:textSize="14sp" />
 
                     <TextView
@@ -52,7 +52,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="20dp"
-                        android:textColor="@color/white"
+                        android:textColor="@color/color_text_primary"
                         android:textSize="40sp"
                         android:textStyle="bold" />
 
@@ -78,7 +78,7 @@
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             android:layout_weight="1"
-                            android:textColor="@color/white"
+                            android:textColor="@color/color_text_primary"
                             android:textSize="14sp"
                             android:textStyle="bold" />
 
@@ -88,7 +88,7 @@
                             android:layout_height="wrap_content"
                             android:layout_weight="1"
                             android:gravity="end"
-                            android:textColor="@color/white"
+                            android:textColor="@color/color_text_primary"
                             android:textSize="14sp"
                             android:textStyle="bold" />
                     </LinearLayout>
@@ -98,7 +98,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="6dp"
-                        android:textColor="@color/white"
+                        android:textColor="@color/color_text_secondary"
                         android:textSize="14sp" />
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/fragment_hydration.xml
+++ b/app/src/main/res/layout/fragment_hydration.xml
@@ -31,7 +31,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/hydration_tracker"
-                    android:textColor="@color/white"
+                    android:textColor="@color/color_text_primary"
                     android:textSize="26sp"
                     android:textStyle="bold" />
 
@@ -40,7 +40,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="6dp"
                     android:text="@string/hydration_tracker_subtitle"
-                    android:textColor="@color/white"
+                    android:textColor="@color/color_text_secondary"
                     android:textSize="14sp" />
 
                 <com.google.android.material.card.MaterialCardView

--- a/app/src/main/res/layout/fragment_mood_journal.xml
+++ b/app/src/main/res/layout/fragment_mood_journal.xml
@@ -31,7 +31,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/mood_journal_title"
-                    android:textColor="@color/white"
+                    android:textColor="@color/color_text_primary"
                     android:textSize="26sp"
                     android:textStyle="bold" />
 
@@ -40,7 +40,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="6dp"
                     android:text="@string/mood_journal_subtitle"
-                    android:textColor="@color/white"
+                    android:textColor="@color/color_text_secondary"
                     android:textSize="14sp" />
 
                 <TextView
@@ -48,7 +48,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="20dp"
                     android:text="@string/todays_mood"
-                    android:textColor="@color/white"
+                    android:textColor="@color/color_text_primary"
                     android:textSize="16sp"
                     android:textStyle="bold" />
 


### PR DESCRIPTION
## Summary
- replace white header copy on auth, dashboard, habits, hydration, and mood screens with the themed text colors for higher contrast
- adjust the dashboard reset button outline to use the matching secondary color tint

## Testing
- `./gradlew lint` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e409ad91a08321a946a131e11a4e34