### PR TITLE
Improve theme contrast and notification scheduling

### DIFF
--- a/app/src/main/java/com/wellnesstracker/utils/NotificationHelper.kt
+++ b/app/src/main/java/com/wellnesstracker/utils/NotificationHelper.kt
@@ -41,18 +41,22 @@ class NotificationHelper(private val context: Context) {
     }
 
     fun scheduleWaterReminder(intervalMinutes: Int) {
+        val safeInterval = intervalMinutes.coerceAtLeast(15)
+
         val workRequest = PeriodicWorkRequestBuilder<WaterReminderWorker>(
-            intervalMinutes.toLong(), TimeUnit.MINUTES,
+            safeInterval.toLong(), TimeUnit.MINUTES,
             15, TimeUnit.MINUTES // Flex interval
-        ).setConstraints(
-            Constraints.Builder()
-                .setRequiresBatteryNotLow(false)
-                .build()
-        ).build()
+        ).setInitialDelay(safeInterval.toLong(), TimeUnit.MINUTES)
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiresBatteryNotLow(false)
+                    .build()
+            )
+            .build()
 
         WorkManager.getInstance(context).enqueueUniquePeriodicWork(
             WORK_NAME,
-            ExistingPeriodicWorkPolicy.UPDATE,
+            ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE,
             workRequest
         )
     }

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="color_base">#0F172A</color>
+    <color name="color_base_variant">#1E293B</color>
+    <color name="color_surface">#1E293B</color>
+    <color name="color_surface_soft">#24324D</color>
+    <color name="color_secondary">#93C5FD</color>
+    <color name="color_secondary_variant">#60A5FA</color>
+    <color name="color_accent">#3B82F6</color>
+    <color name="color_accent_variant">#60A5FA</color>
+    <color name="color_text_primary">#F8FAFC</color>
+    <color name="color_text_secondary">#CBD5F5</color>
+    <color name="color_icon_tint">#94A3B8</color>
+    <color name="color_divider">#334155</color>
+    <color name="color_dashed_border">#475569</color>
+    <color name="gradient_dashboard_start">#4338CA</color>
+    <color name="gradient_dashboard_end">#0EA5E9</color>
+    <color name="gradient_mood_start">#4338CA</color>
+    <color name="gradient_mood_end">#6366F1</color>
+    <color name="gradient_hydration_start">#1D4ED8</color>
+    <color name="gradient_hydration_end">#0EA5E9</color>
+    <color name="gradient_habits_start">#1E40AF</color>
+    <color name="gradient_habits_end">#2563EB</color>
+    <color name="mood_button_default">#1E293B</color>
+    <color name="mood_chip_bg_default">#1F2A44</color>
+    <color name="mood_chip_bg_checked">#3B82F6</color>
+    <color name="mood_chip_text_default">#F8FAFC</color>
+    <color name="mood_chip_text_checked">#FFFFFFFF</color>
+    <color name="color_editing_banner">#1D4ED8</color>
+    <color name="bottom_nav_active">#93C5FD</color>
+    <color name="bottom_nav_inactive">#475569</color>
+    <color name="white">#FFFFFFFF</color>
+    <color name="black">#FF000000</color>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -8,9 +8,15 @@
         <item name="colorOnSecondary">@color/white</item>
         <item name="colorSecondaryContainer">@color/color_accent_variant</item>
         <item name="colorSurface">@color/color_surface</item>
+        <item name="colorOnSurface">@color/color_text_primary</item>
+        <item name="colorBackground">@color/color_base</item>
+        <item name="colorOnBackground">@color/color_text_primary</item>
 
         <item name="android:windowBackground">@color/color_base</item>
-
+        <item name="android:textColor">@color/color_text_primary</item>
+        <item name="android:textColorPrimary">@color/color_text_primary</item>
+        <item name="android:textColorSecondary">@color/color_text_secondary</item>
+        <item name="android:textColorHint">@color/color_icon_tint</item>
         <item name="android:colorBackground">@color/color_base</item>
         <item name="android:statusBarColor">@color/color_secondary</item>
         <item name="android:navigationBarColor">@color/color_secondary</item>


### PR DESCRIPTION
## Summary
- add a dedicated night color palette and wire the theme to use explicit foreground colors so text stays legible
- ensure water reminder scheduling enforces valid intervals and refreshes the WorkManager request reliably

## Testing
- not run (android)


------
https://chatgpt.com/codex/tasks/task_e_68e4297d4e308321991f156cc5dfe5bc