### PR TITLE
Add hydration reminder scheduling and fix header gradients

### DIFF
--- a/app/src/main/java/com/wellnesstracker/fragments/HydrationFragment.kt
+++ b/app/src/main/java/com/wellnesstracker/fragments/HydrationFragment.kt
@@ -5,12 +5,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.wellnesstracker.R
 import com.wellnesstracker.databinding.FragmentHydrationBinding
 import com.wellnesstracker.utils.DataManager
+import com.wellnesstracker.utils.NotificationHelper
 import java.text.NumberFormat
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -21,6 +24,7 @@ class HydrationFragment : Fragment() {
     private var _binding: FragmentHydrationBinding? = null
     private val binding get() = _binding!!
     private lateinit var dataManager: DataManager
+    private lateinit var notificationHelper: NotificationHelper
     private var customAmount = 250
 
     override fun onCreateView(
@@ -35,15 +39,18 @@ class HydrationFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         dataManager = DataManager(requireContext())
+        notificationHelper = NotificationHelper(requireContext())
 
         setupQuickButtons()
         setupCustomControls()
+        setupReminderControls()
         updateHydrationSummary()
     }
 
     override fun onResume() {
         super.onResume()
         updateHydrationSummary()
+        updateReminderStatus()
     }
 
     private fun setupQuickButtons() {
@@ -83,6 +90,74 @@ class HydrationFragment : Fragment() {
     private fun addHydration(amount: Int) {
         dataManager.addHydrationEntry(amount)
         updateHydrationSummary()
+    }
+
+    private fun setupReminderControls() {
+        updateReminderStatus()
+
+        binding.buttonSetReminder.setOnClickListener {
+            showReminderDialog()
+        }
+
+        binding.buttonCancelReminder.setOnClickListener {
+            notificationHelper.cancelOneTimeWaterReminder()
+            updateReminderStatus()
+            Toast.makeText(requireContext(), R.string.hydration_reminder_cancelled, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun showReminderDialog() {
+        val options = listOf(
+            10L to getString(R.string.reminder_option_seconds, 10),
+            30L to getString(R.string.reminder_option_seconds, 30),
+            60L to getString(R.string.reminder_option_minutes, 1),
+            5 * 60L to getString(R.string.reminder_option_minutes, 5),
+            15 * 60L to getString(R.string.reminder_option_minutes, 15),
+            30 * 60L to getString(R.string.reminder_option_minutes, 30)
+        )
+
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.hydration_reminder_dialog_title)
+            .setItems(options.map { it.second }.toTypedArray()) { _, which ->
+                val (delaySeconds, label) = options[which]
+                notificationHelper.scheduleOneTimeWaterReminder(delaySeconds)
+                updateReminderStatus()
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.hydration_reminder_scheduled_for, label),
+                    Toast.LENGTH_SHORT
+                ).show()
+
+                if (!dataManager.areNotificationsEnabled()) {
+                    Toast.makeText(
+                        requireContext(),
+                        R.string.hydration_reminder_permission_warning,
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun updateReminderStatus() {
+        val nextReminder = dataManager.getNextHydrationReminderTime()
+        val isScheduled = nextReminder > System.currentTimeMillis()
+
+        if (isScheduled) {
+            val timeFormatter = SimpleDateFormat("hh:mm a", Locale.getDefault())
+            val formattedTime = timeFormatter.format(Date(nextReminder))
+            binding.textReminderStatus.text =
+                getString(R.string.hydration_reminder_status_at, formattedTime)
+        } else {
+            binding.textReminderStatus.text =
+                getString(R.string.hydration_reminder_status_off)
+            if (nextReminder != 0L) {
+                dataManager.clearNextHydrationReminderTime()
+            }
+        }
+
+        binding.buttonCancelReminder.isVisible = isScheduled
     }
 
     private fun updateHydrationSummary() {
@@ -140,3 +215,4 @@ class HydrationFragment : Fragment() {
         _binding = null
     }
 }
+

--- a/app/src/main/java/com/wellnesstracker/utils/DataManager.kt
+++ b/app/src/main/java/com/wellnesstracker/utils/DataManager.kt
@@ -23,6 +23,7 @@ class DataManager(context: Context) {
         private const val KEY_HYDRATION = "hydration_entries"
         private const val KEY_HYDRATION_GOAL = "hydration_goal"
         private const val KEY_WATER_INTERVAL = "water_interval"
+        private const val KEY_NEXT_WATER_REMINDER = "next_water_reminder_timestamp"
         private const val KEY_NOTIFICATIONS_ENABLED = "notifications_enabled"
     }
 
@@ -203,6 +204,18 @@ class DataManager(context: Context) {
 
     fun getWaterInterval(): Int {
         return prefs.getInt(KEY_WATER_INTERVAL, 60) // Default 60 minutes
+    }
+
+    fun setNextHydrationReminderTime(timestamp: Long) {
+        prefs.edit().putLong(KEY_NEXT_WATER_REMINDER, timestamp).apply()
+    }
+
+    fun getNextHydrationReminderTime(): Long {
+        return prefs.getLong(KEY_NEXT_WATER_REMINDER, 0L)
+    }
+
+    fun clearNextHydrationReminderTime() {
+        prefs.edit().remove(KEY_NEXT_WATER_REMINDER).apply()
     }
 
     fun setNotificationsEnabled(enabled: Boolean) {

--- a/app/src/main/res/drawable/ic_bell.xml
+++ b/app/src/main/res/drawable/ic_bell.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.9,2 2,2zM18,16v-5c0,-3.07 -1.63,-5.64 -4.5,-6.32V4c0,-0.83 -0.67,-1.5 -1.5,-1.5S10.5,3.17 10.5,4v0.68C7.63,5.36 6,7.92 6,11v5l-1.7,1.7c-0.14,0.14 -0.3,0.33 -0.3,0.55 0,0.43 0.35,0.75 0.78,0.75h14.44c0.43,0 0.78,-0.32 0.78,-0.75 0,-0.22 -0.09,-0.41 -0.23,-0.55L18,16z" />
+</vector>

--- a/app/src/main/res/layout/fragment_dashboard.xml
+++ b/app/src/main/res/layout/fragment_dashboard.xml
@@ -18,6 +18,7 @@
             android:layout_marginBottom="20dp"
             android:background="@drawable/bg_dashboard_header"
             android:clipToPadding="false"
+            app:cardBackgroundColor="@android:color/transparent"
             app:cardCornerRadius="28dp"
             app:cardElevation="0dp"
             app:strokeWidth="0dp">

--- a/app/src/main/res/layout/fragment_habits.xml
+++ b/app/src/main/res/layout/fragment_habits.xml
@@ -21,6 +21,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="20dp"
                 android:background="@drawable/bg_habits_header"
+                app:cardBackgroundColor="@android:color/transparent"
                 app:cardCornerRadius="28dp"
                 app:cardElevation="0dp"
                 app:strokeWidth="0dp">

--- a/app/src/main/res/layout/fragment_hydration.xml
+++ b/app/src/main/res/layout/fragment_hydration.xml
@@ -17,6 +17,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="20dp"
             android:background="@drawable/bg_hydration_header"
+            app:cardBackgroundColor="@android:color/transparent"
             app:cardCornerRadius="28dp"
             app:cardElevation="0dp"
             app:strokeWidth="0dp">
@@ -112,6 +113,51 @@
                     app:iconPadding="12dp"
                     app:iconTint="@color/white"
                     app:rippleColor="@color/color_accent_variant" />
+
+                <TextView
+                    android:id="@+id/text_reminder_status"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/hydration_reminder_status_off"
+                    android:textColor="@color/color_surface_soft"
+                    android:textSize="14sp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/button_set_reminder"
+                        style="@style/Widget.MaterialComponents.Button"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/set_hydration_reminder"
+                        android:textAllCaps="false"
+                        android:textColor="@color/white"
+                        app:backgroundTint="@color/color_accent"
+                        app:cornerRadius="20dp"
+                        app:icon="@drawable/ic_bell"
+                        app:iconGravity="textStart"
+                        app:iconPadding="12dp"
+                        app:iconTint="@color/white"
+                        app:rippleColor="@color/color_accent_variant" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/button_cancel_reminder"
+                        style="@style/Widget.MaterialComponents.Button.TextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="12dp"
+                        android:text="@string/cancel_hydration_reminder"
+                        android:textAllCaps="false"
+                        android:textColor="@color/color_surface_soft"
+                        android:visibility="gone" />
+                </LinearLayout>
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/layout/fragment_mood_journal.xml
+++ b/app/src/main/res/layout/fragment_mood_journal.xml
@@ -18,6 +18,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="20dp"
             android:background="@drawable/bg_mood_header"
+            app:cardBackgroundColor="@android:color/transparent"
             app:cardCornerRadius="28dp"
             app:cardElevation="0dp"
             app:strokeWidth="0dp">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,16 @@
     <string name="tip_two">⏰ Set reminders every 2 hours during the day.</string>
     <string name="tip_three">🥗 Eat water-rich foods like fruits and vegetables.</string>
     <string name="tip_four">🏃‍♀️ Drink extra water before, during, and after exercise.</string>
+    <string name="set_hydration_reminder">Schedule reminder</string>
+    <string name="cancel_hydration_reminder">Cancel reminder</string>
+    <string name="hydration_reminder_status_off">No reminder scheduled</string>
+    <string name="hydration_reminder_status_at">Reminder set for %1$s</string>
+    <string name="hydration_reminder_dialog_title">Pick reminder delay</string>
+    <string name="reminder_option_seconds">%1$d seconds</string>
+    <string name="reminder_option_minutes">%1$d minutes</string>
+    <string name="hydration_reminder_scheduled_for">Hydration reminder scheduled for %1$s</string>
+    <string name="hydration_reminder_cancelled">Hydration reminder cancelled</string>
+    <string name="hydration_reminder_permission_warning">Enable notifications in Settings to make sure reminders appear.</string>
 
     <!-- Formatting strings -->
     <string name="format_daily_goal">Daily goal: %1$d ml</string>


### PR DESCRIPTION
## Summary
- ensure gradient header cards render by making MaterialCard backgrounds transparent
- add a hydration reminder section with schedule/cancel controls and supporting strings/assets
- persist next reminder timestamps and schedule one-time water reminder work with short delays

## Testing
- ./gradlew assembleDebug *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f6b0915c8321958d05f7d19e450c